### PR TITLE
fix(ci): switch pr-gate from VidiomTM self-hosted to ubuntu-latest

### DIFF
--- a/.github/workflows/pr-gate.yml
+++ b/.github/workflows/pr-gate.yml
@@ -97,10 +97,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
-      - name: Install and run vitest-linter
-        run: |
-          npm install -g vitest-linter 2>/dev/null || true
-          vitest-linter . --format terminal
+      - uses: VidiomTM/vitest-linter@v1.0.0
 
   required-checks:
     name: Required Checks (PR)

--- a/.github/workflows/pr-gate.yml
+++ b/.github/workflows/pr-gate.yml
@@ -84,7 +84,7 @@ jobs:
           go-version: "1.24"
       - name: Build structurelint
         run: |
-          git clone --depth 1 --branch v0.1.0 https://github.com/Jonathangadeaharder/structurelint.git /tmp/structurelint
+          git clone --depth 1 --branch v1.0.2 https://github.com/Jonathangadeaharder/structurelint.git /tmp/structurelint
           cd /tmp/structurelint && go build -o /tmp/structurelint-bin ./cmd/structurelint
       - name: Run structurelint
         run: /tmp/structurelint-bin .
@@ -97,7 +97,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
-      - uses: Jonathangadeaharder/vitest-linter@v1
+      - uses: VidiomTM/vitest-linter@v1
 
   required-checks:
     name: Required Checks (PR)

--- a/.github/workflows/pr-gate.yml
+++ b/.github/workflows/pr-gate.yml
@@ -14,7 +14,7 @@ concurrency:
 jobs:
   repo-hygiene:
     name: Repo Hygiene
-    runs-on: ["self-hosted", "macos", "arm64", "VidiomTM"]
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
       - name: Check for iCloud sync conflicts
@@ -27,7 +27,7 @@ jobs:
 
   node-quality:
     name: Node Quality
-    runs-on: ["self-hosted", "macos", "arm64", "VidiomTM"]
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
       - name: Setup pnpm
@@ -50,29 +50,33 @@ jobs:
 
   dependency-scan:
     name: Dependency Scan
-    runs-on: ["self-hosted", "macos", "arm64", "VidiomTM"]
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
-      - name: Install Trivy
-        run: brew install aquasecurity/trivy/trivy
       - name: Run Trivy filesystem scan
-        run: trivy fs --exit-code 1 --severity HIGH,CRITICAL --ignore-unfixed .
+        uses: aquasecurity/trivy-action@0.35.0
+        with:
+          scan-type: 'fs'
+          scan-ref: '.'
+          severity: 'HIGH,CRITICAL'
+          exit-code: '1'
+          ignore-unfixed: true
 
   secret-scanning:
     name: Secret Scanning
-    runs-on: ["self-hosted", "macos", "arm64", "VidiomTM"]
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
         with:
           fetch-depth: 0
-      - name: Install gitleaks
-        run: brew install gitleaks
-      - name: Run gitleaks
-        run: gitleaks detect --verbose
+      - name: gitleaks
+        uses: gitleaks/gitleaks-action@v2
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
   structure:
     name: Repository Structure
-    runs-on: ["self-hosted", "macos", "arm64", "VidiomTM"]
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
       - uses: actions/setup-go@v5
@@ -90,14 +94,14 @@ jobs:
 
   vitest-lint:
     name: Test Quality (Vitest)
-    runs-on: ["self-hosted", "macos", "arm64", "VidiomTM"]
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
       - uses: Jonathangadeaharder/vitest-linter@v1
 
   required-checks:
     name: Required Checks (PR)
-    runs-on: ["self-hosted", "macos", "arm64", "VidiomTM"]
+    runs-on: ubuntu-latest
     needs:
       - repo-hygiene
       - node-quality

--- a/.github/workflows/pr-gate.yml
+++ b/.github/workflows/pr-gate.yml
@@ -97,13 +97,16 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
-      - uses: actions/setup-go@v5
-        with:
-          go-version: "1.24"
       - name: Install and run vitest-linter
         run: |
-          go install github.com/VidiomTM/vitest-linter/cmd/vitest-linter@v1.0.0
+          git clone --depth 1 --branch v1.0.0 https://github.com/VidiomTM/vitest-linter.git /tmp/vitest-linter
+          cd /tmp/vitest-linter && cargo build --release -q
+          cp /tmp/vitest-linter/target/release/vitest-linter /usr/local/bin/
+          cd $GITHUB_WORKSPACE
           vitest-linter . --format terminal
+      - name: Cleanup vitest-linter
+        if: always()
+        run: rm -rf /tmp/vitest-linter
 
   required-checks:
     name: Required Checks (PR)

--- a/.github/workflows/pr-gate.yml
+++ b/.github/workflows/pr-gate.yml
@@ -97,7 +97,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
-      - uses: VidiomTM/vitest-linter@v1
+      - name: Install and run vitest-linter
+        run: |
+          npm install -g vitest-linter 2>/dev/null || true
+          vitest-linter . --format terminal
 
   required-checks:
     name: Required Checks (PR)

--- a/.github/workflows/pr-gate.yml
+++ b/.github/workflows/pr-gate.yml
@@ -97,7 +97,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
-      - uses: VidiomTM/vitest-linter@v1.0.0
+      - uses: actions/setup-go@v5
+        with:
+          go-version: "1.24"
+      - name: Install and run vitest-linter
+        run: |
+          go install github.com/VidiomTM/vitest-linter/cmd/vitest-linter@v1.0.0
+          vitest-linter . --format terminal
 
   required-checks:
     name: Required Checks (PR)

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "test": "vitest run",
     "test:watch": "vitest"
   },
+  "packageManager": "pnpm@9.15.0",
   "type": "module",
   "dependencies": {
     "@threlte/core": "^8.5.16",


### PR DESCRIPTION
## Problem
All PR gate jobs stuck in `queued` indefinitely. The workflow uses `runs-on: [self-hosted, macos, arm64, VidiomTM]` but those runners are registered under the **VidiomTM org** runner group. GitHub runner groups are org-scoped — they cannot serve repos in the `Jonathangadeaharder` org.

The repo-level runners (`ImperioCasino-python-gate`, `ImperioCasino-security-gate`) are **offline** and have different labels (X64, no VidiomTM tag).

## Fix
Convert `pr-gate.yml` to use `ubuntu-latest` (GitHub-hosted), matching the pattern already used in `merge-gate.yml`.

Changes:
- All `runs-on` → `ubuntu-latest`
- `brew install trivy` → `aquasecurity/trivy-action@0.35.0` (same as merge-gate)
- `brew install gitleaks` → `gitleaks/gitleaks-action@v2` (same as merge-gate)

## Verification
Once merged, re-run the pending CI on #92 to confirm jobs execute.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * CI/CD gates moved to standardized Linux runners and scanning steps modernized for more consistent, reliable checks.
  * Secret and dependency scans updated to use maintained GitHub actions and full-repository inspection for stronger coverage.
  * Structural lint tooling upgraded and the project package manager declared (pnpm@9.15.0) to standardize installs; no user-facing behavior changes.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Jonathangadeaharder/ImperioCasino/pull/107?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->